### PR TITLE
Add assertions to getResponse and Parser methods

### DIFF
--- a/src/main/java/mychatbot/MyChatBot.java
+++ b/src/main/java/mychatbot/MyChatBot.java
@@ -30,6 +30,7 @@ public class MyChatBot {
      * Any invalid commands or errors are reported to the user via the UI class.
      */
     public String getResponse(String userInput) {
+        assert userInput != null : "User input should not be null";
         String response;
         String command = Parser.getCommandType(userInput);
         try {
@@ -42,12 +43,14 @@ public class MyChatBot {
                 break;
             case "mark":
                 int markIndex = Parser.getTaskIndex(userInput);
+                assert markIndex < tasks.size() : "Mark index out of bounds";
                 tasks.getTask(markIndex).markAsDone();
                 storage.save(tasks.getTasks());
                 response = ui.markTaskUi(tasks.getTask(markIndex));
                 break;
             case "unmark":
                 int unmarkIndex = Parser.getTaskIndex(userInput);
+                assert unmarkIndex < tasks.size() : "Unmark index out of bounds";
                 tasks.getTask(unmarkIndex).markAsNotDone();
                 storage.save(tasks.getTasks());
                 response = ui.unmarkTaskUi(tasks.getTask(unmarkIndex));
@@ -61,6 +64,7 @@ public class MyChatBot {
                 break;
             case "deadline":
                 String[] deadlineParts = Parser.getDeadlineParts(userInput);
+                assert deadlineParts.length == 2: "Deadline parts should have description and due date";
                 Task deadline = new Deadline(deadlineParts[0], false, deadlineParts[1]);
                 tasks.addTask(deadline);
                 storage.save(tasks.getTasks());
@@ -68,6 +72,7 @@ public class MyChatBot {
                 break;
             case "event":
                 String[] eventParts = Parser.getEventParts(userInput);
+                assert eventParts.length == 3: "Event parts should have description, start and end time";
                 Task event = new Event(eventParts[0], false, eventParts[1], eventParts[2]);
                 tasks.addTask(event);
                 storage.save(tasks.getTasks());
@@ -75,6 +80,7 @@ public class MyChatBot {
                 break;
             case "find":
                 String keyword = Parser.getDescription(userInput);
+                assert !keyword.isEmpty() : "Keyword should not be empty";
                 ArrayList<Task> matchingTasks = tasks.findTasks(keyword);
                 response = ui.printMatchingTasks(matchingTasks);
                 break;

--- a/src/main/java/mychatbot/Parser.java
+++ b/src/main/java/mychatbot/Parser.java
@@ -10,6 +10,7 @@ public class Parser {
      * @return The command.
      */
     public static String getCommandType(String input) {
+        assert input != null : "Input should not be null";
         String[] tokens = input.trim().split(" ", 2);
         return tokens[0];
     }
@@ -22,15 +23,14 @@ public class Parser {
      * @throws MyChatBotException If the format or number of the input string is invalid.
      */
     public static int getTaskIndex(String input) throws MyChatBotException {
+        assert input != null : "Input should not be null";
         try {
             String[] tokens = input.trim().split(" ");
             if (tokens.length < 2) {
                 throw new MyChatBotException("Invalid format, it should be: 'mark <number>'");
             }
             int idx = Integer.parseInt(tokens[1]) - 1;
-            if (idx < 0) {
-                throw new MyChatBotException("Task number must be positive.");
-            }
+            assert idx >= 0 : "Task index should be non-negative";
             return idx;
         } catch (NumberFormatException e) {
             throw new MyChatBotException("Invalid task number.");
@@ -45,6 +45,7 @@ public class Parser {
      * @return The description of the Todo in the user input.
      */
     public static String getDescription(String input) {
+        assert input != null : "Input should not be null";
         return input.substring(input.indexOf(" ") + 1).trim();
     }
 
@@ -54,9 +55,11 @@ public class Parser {
      * @return The description and deadline of the Deadline in the user input as String[].
      */
     public static String[] getDeadlineParts(String input) throws MyChatBotException {
+        assert input != null : "Input should not be null";
         try {
             String body = input.substring(8).trim();
             int byIdx = body.indexOf(" /by ");
+            assert byIdx != -1 : "Input should contain '/by' for deadline";
 
             String desc = body.substring(0, byIdx);
             String by = body.substring(byIdx + 5);
@@ -75,10 +78,13 @@ public class Parser {
      * @return The description, start and end times of the Event in the user input as String[].
      */
     public static String[] getEventParts(String input) throws MyChatBotException {
+        assert input != null : "Input should not be null";
         try {
             String body = input.substring(5).trim();
             int fromIdx = body.indexOf(" /from ");
             int toIdx = body.indexOf(" /to ");
+            assert fromIdx != -1 : "Input should contain '/from' for event";
+            assert toIdx != -1 : "Input should contain '/to' for event";
 
             String desc = body.substring(0, fromIdx);
             String from = body.substring(fromIdx + 7, toIdx);

--- a/src/main/java/mychatbot/TaskList.java
+++ b/src/main/java/mychatbot/TaskList.java
@@ -21,7 +21,10 @@ public class TaskList {
         return tasks;
     }
 
-    public Task getTask(int idx) {
+    public Task getTask(int idx) throws MyChatBotException {
+        if (idx < 0 || idx >= tasks.size()) {
+            throw new MyChatBotException("Task number is out of bounds.");
+        }
         return tasks.get(idx);
     }
 

--- a/src/main/java/mychatbot/Ui.java
+++ b/src/main/java/mychatbot/Ui.java
@@ -15,7 +15,7 @@ public class Ui {
         return "Got it. I've added this task:\n  " + task + "\nNow you have " + size + " tasks in the list.";
     }
 
-    public String printList(TaskList list) {
+    public String printList(TaskList list) throws MyChatBotException {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Here are the tasks in your list:\n");
         for (int i = 0; i < list.size(); i++) {


### PR DESCRIPTION
The Parser methods and MyChatBot.getResponse method lacked runtime checks for important preconditions. Thus, unexpected input could cause errors like uncaught exceptions, which would make debugging difficult.

Assertions help to clarify the developers' expectations and document important assumptions about the code they are working on. Enabling assertions at runtime helps to catch violations early in development.

Let's:
* add non-null input assertions for all relevant methods in Parser and in getResponse
* assert that task indices are within valid bounds
* assert that descriptions are non-empty
* assert that parts are correctly counted when parsing deadline, event and todo commands